### PR TITLE
ARC-1296: Align GesundheitsID title

### DIFF
--- a/ehealthid-rp/src/main/resources/www/select-idp.html.mustache
+++ b/ehealthid-rp/src/main/resources/www/select-idp.html.mustache
@@ -60,9 +60,9 @@
     </style>
   {{/head}}
   {{$body}}
-    <h1>GesundheitsID</h1>
     <form action="/auth/select-idp" method="post" class="form-inline">
       <div class="provider-wrapper">
+        <h1>GesundheitsID</h1>
         <label for="idp-selection">Select your GesundheitsID Provider</label>
         <select name="identityProvider" id="idp-selection">
           {{#identityProviders}}

--- a/ehealthid-rp/src/test/resources/fixtures/pages_golden_idp-select-form.bin
+++ b/ehealthid-rp/src/test/resources/fixtures/pages_golden_idp-select-form.bin
@@ -127,9 +127,9 @@ a {
 </head>
 <body>
 <div class="container">
-      <h1>GesundheitsID</h1>
-    <form action="/auth/select-idp" method="post" class="form-inline">
+      <form action="/auth/select-idp" method="post" class="form-inline">
       <div class="provider-wrapper">
+        <h1>GesundheitsID</h1>
         <label for="idp-selection">Select your GesundheitsID Provider</label>
         <select name="identityProvider" id="idp-selection">
             <option value="https://a.example.com">AoK Tesfalen</option>


### PR DESCRIPTION
### Changes:
- Align form title to the center as requested by Silvia
![Screenshot 2024-02-19 at 09 23 57](https://github.com/oviva-ag/ehealthid-relying-party/assets/90144383/f2e4bbf4-f538-4df9-a6dc-0cee4786d7bf)

