### PR TITLE
Fix MediaType for Prometheus Endpoint

### DIFF
--- a/ehealthid-rp/src/main/java/com/oviva/ehealthid/relyingparty/ws/MetricsEndpoint.java
+++ b/ehealthid-rp/src/main/java/com/oviva/ehealthid/relyingparty/ws/MetricsEndpoint.java
@@ -8,6 +8,8 @@ import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
 @Path("/metrics")
@@ -26,7 +28,8 @@ public class MetricsEndpoint {
   }
 
   @GET
+  @Produces(MediaType.TEXT_PLAIN)
   public Response get() {
-    return Response.ok(this.registry.scrape()).build();
+    return Response.ok(this.registry.scrape(), MediaType.TEXT_PLAIN_TYPE).build();
   }
 }

--- a/ehealthid-rp/src/test/java/com/oviva/ehealthid/relyingparty/ws/MetricsEndpointTest.java
+++ b/ehealthid-rp/src/test/java/com/oviva/ehealthid/relyingparty/ws/MetricsEndpointTest.java
@@ -27,5 +27,6 @@ class MetricsEndpointTest {
     // then
     assertEquals(Status.OK.getStatusCode(), res.getStatus());
     assertTrue(res.getEntity().toString().contains("test_counter_total 2.0"));
+    assertEquals("[text/plain]", res.getHeaders().get("Content-Type").toString());
   }
 }


### PR DESCRIPTION
**Fixed**

- MediaType for scrape endpoint


---

**Context**

Prometheus sets the following header: `Accept: application/openmetrics-text; version=0.0.1,text/plain;version=0.0.4;q=0.5,*/*;q=0.1` when scraping. Without an explicit media type, the underlying server will respond with a content type of `application/openmetrics-text` while the actual type of the content is `text/plain` which will lead to an error when Prometheus tries to parse the body.

Just noticed that when deploying the service. Sorry I missed it, the first time around.