### PR TITLE
ARC-2937: Upgrading org.apache.commons:commons-lang3 from 3.17.0 to 3…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
-        <version>3.17.0</version>
+        <version>3.18.0</version>
       </dependency>
       <dependency>
         <groupId>com.github.jknack</groupId>


### PR DESCRIPTION
….18.0