### PR TITLE
Adjustments for new registration format in federation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ dependency-reduced-pom.xml
 .DS_Store
 logs.json
 fedreg_*.xml
+.local

--- a/ehealthid-cli/src/main/java/com/oviva/ehealthid/cli/FedRegistrationCommand.java
+++ b/ehealthid-cli/src/main/java/com/oviva/ehealthid/cli/FedRegistrationCommand.java
@@ -8,7 +8,6 @@ import com.nimbusds.jose.jwk.KeyUse;
 import com.oviva.ehealthid.cli.forms.RegistratonFormRenderer;
 import com.oviva.ehealthid.cli.forms.RegistratonFormRenderer.Model;
 import com.oviva.ehealthid.cli.forms.RegistratonFormRenderer.Model.Environment;
-import com.oviva.ehealthid.cli.forms.RegistratonFormRenderer.Model.Scope;
 import com.oviva.ehealthid.fedclient.api.EntityStatementJWS;
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -22,7 +21,6 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Callable;
-import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
@@ -135,11 +133,13 @@ public class FedRegistrationCommand implements Callable<Integer> {
         new Model(
             vfsConfirmation,
             memberId,
-            entityConfiguration.orgName(),
+            entityConfiguration.organisationName(),
+            entityConfiguration.fachdienstName(),
             contactEmail,
             issuerUri,
             environment,
             entityConfiguration.scopes(),
+            entityConfiguration.redirectUris(),
             entityConfiguration.jwks()));
   }
 
@@ -184,11 +184,16 @@ public class FedRegistrationCommand implements Callable<Integer> {
       logger.atInfo().log("retrieved entity configuration from '{}'", entityConfigurationUri);
 
       var entityStatement = EntityStatementJWS.parse(res.body());
+      var rp = entityStatement.body().metadata().openIdRelyingParty();
+      var scopes = Arrays.asList(rp.scope().split(" "));
+      var redirectUris = rp.redirectUris() != null ? rp.redirectUris() : List.<String>of();
       return new EntityConfiguration(
           entityStatement.body().sub(),
           entityStatement.body().jwks(),
+          rp.organizationName(),
           entityStatement.body().metadata().federationEntity().name(),
-          parseScopes(entityStatement.body().metadata().openIdRelyingParty().scope()));
+          scopes,
+          redirectUris);
 
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
@@ -259,25 +264,6 @@ public class FedRegistrationCommand implements Callable<Integer> {
     }
   }
 
-  private List<Scope> parseScopes(String scopes) {
-    return Arrays.stream(scopes.split(" "))
-        .flatMap(
-            s ->
-                switch (s) {
-                  // https://gemspec.gematik.de/docs/gemSpec/gemSpec_IDP_Sek/gemSpec_IDP_Sek_V2.3.0/index.html#A_22989-01
-                  case "urn:telematik:geburtsdatum" -> Stream.of(Scope.DATE_OF_BIRTH);
-                  case "urn:telematik:alter" -> Stream.of(Scope.AGE);
-                  case "urn:telematik:display_name" -> Stream.of(Scope.DISPLAY_NAME);
-                  case "urn:telematik:given_name" -> Stream.of(Scope.FIRST_NAME);
-                  case "urn:telematik:family_name" -> Stream.of(Scope.LAST_NAME);
-                  case "urn:telematik:geschlecht" -> Stream.of(Scope.GENDER);
-                  case "urn:telematik:email" -> Stream.of(Scope.EMAIL);
-                  case "urn:telematik:versicherter" -> Stream.of(Scope.INSURED_PERSON);
-                  default -> Stream.empty();
-                })
-        .toList();
-  }
-
   private void validateKey(JWK key, KeyUse keyUse) {
 
     if (key.getKeyID() == null || key.getKeyID().isBlank()) {
@@ -304,5 +290,11 @@ public class FedRegistrationCommand implements Callable<Integer> {
     }
   }
 
-  record EntityConfiguration(String sub, JWKSet jwks, String orgName, List<Scope> scopes) {}
+  record EntityConfiguration(
+      String sub,
+      JWKSet jwks,
+      String organisationName,
+      String fachdienstName,
+      List<String> scopes,
+      List<String> redirectUris) {}
 }

--- a/ehealthid-cli/src/main/java/com/oviva/ehealthid/cli/forms/RegistratonFormRenderer.java
+++ b/ehealthid-cli/src/main/java/com/oviva/ehealthid/cli/forms/RegistratonFormRenderer.java
@@ -3,7 +3,6 @@ package com.oviva.ehealthid.cli.forms;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.JWKSet;
-import com.oviva.ehealthid.cli.forms.RegistratonFormRenderer.Model.Scope;
 import java.net.URI;
 import java.security.Key;
 import java.util.Base64;
@@ -11,99 +10,56 @@ import java.util.List;
 
 public class RegistratonFormRenderer {
 
-  // the PU registration XML differs from others
-  private static final String XML_TEMPLATE_PROD =
+  private static final String XML_TEMPLATE =
       """
-                    <?xml version="1.0" encoding="UTF-8"?>
-                    <registrierungtifoederation>
-                      <datendesantragstellers>
-                      <vfsbestaetigung>{{vfsConfirmation}}</vfsbestaetigung>
-                      <teilnehmertyp>Fachdienst</teilnehmertyp>
-                      <organisationsname>{{organisationName}}</organisationsname>
-                      <memberid>{{memberId}}</memberid>
-                      <zwg>ORG-0229:BT-0170</zwg>
-                      <issueruri>{{issuerUri}}</issueruri>
-                      <scopes>
-                        <scopealter>{{scopeAge}}</scopealter>
-                        <scopeanzeigename>{{scopeDisplayName}}</scopeanzeigename>
-                        <scopeemail>{{scopeEmail}}</scopeemail>
-                        <scopegeschlecht>{{scopeGender}}</scopegeschlecht>
-                        <scopegeburtsdatum>{{scopeDateOfBirth}}</scopegeburtsdatum>
-                        <scopevorname>{{scopeFirstName}}</scopevorname>
-                        <scopenachname>{{scopeLastName}}</scopenachname>
-                        <scopeversicherter>{{scopeInsuredPerson}}</scopeversicherter>
-                      </scopes>
-                      {{#publicKeys}}
-                      <publickeys>
-                        <kidjwt>{{kid}}</kidjwt>
-                        <pubkeyjwt>{{pem}}</pubkeyjwt>
-                      </publickeys>
-                      {{/publicKeys}}
-                      </datendesantragstellers>
-                    </registrierungtifoederation>
-                    """;
-
-  private static final String XML_TEMPLATE_TEST =
-      """
-                    <?xml version="1.0" encoding="UTF-8"?>
-                    <registrierungtifoederation>
-                       <datendesantragstellers>
-                         <kontaktemail>{{contactEmail}}</kontaktemail>
-                         <teilnehmertyp>Fachdienst</teilnehmertyp>
-                         <betriebsumgebung>{{environment}}</betriebsumgebung>
-                         <organisationsname>{{organisationName}}</organisationsname>
-                         <memberid>{{memberId}}</memberid>
-                         <zwg>ORG-0001:BT-0144</zwg>
-                         <issueruri>{{issuerUri}}</issueruri>
-                         <scopes>
-                           <scopealter>{{scopeAge}}</scopealter>
-                           <scopeanzeigename>{{scopeDisplayName}}</scopeanzeigename>
-                           <scopeemail>{{scopeEmail}}</scopeemail>
-                           <scopegeschlecht>{{scopeGender}}</scopegeschlecht>
-                           <scopegeburtsdatum>{{scopeDateOfBirth}}</scopegeburtsdatum>
-                           <scopevorname>{{scopeFirstName}}</scopevorname>
-                           <scopenachname>{{scopeLastName}}</scopenachname>
-                           <scopeversicherter>{{scopeInsuredPerson}}</scopeversicherter>
-                         </scopes>
-                         {{#publicKeys}}
-                         <publickeys>
-                           <kidjwt>{{kid}}</kidjwt>
-                           <pubkeyjwt>{{pem}}</pubkeyjwt>
-                         </publickeys>
-                         {{/publicKeys}}
-                       </datendesantragstellers>
-                    </registrierungtifoederation>
-                    """;
+      <?xml version="1.0" encoding="UTF-8"?>
+      <registrierungtifoederation>
+        <teilnehmertyp>Fachdienst</teilnehmertyp>
+        <betriebsumgebung>{{environment}}</betriebsumgebung>
+        <kontaktemail>{{contactEmail}}</kontaktemail>
+        <vfsbestaetigung>{{vfsConfirmation}}</vfsbestaetigung>
+        <zuweisungsgruppe>ORG-0229:BT-0170</zuweisungsgruppe>
+        <memberid>{{memberId}}</memberid>
+        <organisationsname>{{organisationName}}</organisationsname>
+        <fachdienstname>{{fachdienstName}}</fachdienstname>
+        <fachdiensturi>{{fachdienstUri}}</fachdiensturi>
+        <scopes>
+      {{#scopes}}
+          <scope>{{value}}</scope>
+      {{/scopes}}
+        </scopes>
+        <claims/>
+        <redirect_uris>
+      {{#redirectUris}}
+          <redirect_uri>{{value}}</redirect_uri>
+      {{/redirectUris}}
+        </redirect_uris>
+        <publickeysjwt>
+      {{#publicKeys}}
+          <publickey>
+            <kid>{{kid}}</kid>
+            <key>{{pem}}</key>
+          </publickey>
+      {{/publicKeys}}
+        </publickeysjwt>
+      </registrierungtifoederation>
+      """;
 
   public static String render(Model m) {
-
-    return switch (m.environment()) {
-      case PU -> renderProductiveEnvironment(m);
-      default -> renderTestEnvironment(m);
-    };
-  }
-
-  private static String renderProductiveEnvironment(Model m) {
-    return renderTemplate(XML_TEMPLATE_PROD, m);
-  }
-
-  private static String renderTestEnvironment(Model m) {
-    return renderTemplate(XML_TEMPLATE_TEST, m);
-  }
-
-  private static String renderTemplate(String template, Model m) {
     var rm = RenderModel.fromModel(m);
-    return MustacheRenderer.render(template, rm);
+    return MustacheRenderer.render(XML_TEMPLATE, rm);
   }
 
   public record Model(
       String vfsConfirmation,
       String memberId,
       String organisationName,
+      String fachdienstName,
       String contactEmail,
       URI issuerUri,
       Environment environment,
-      List<Scope> scopes,
+      List<String> scopes,
+      List<String> redirectUris,
       JWKSet jwks) {
 
     public enum Environment {
@@ -111,55 +67,36 @@ public class RegistratonFormRenderer {
       TU,
       PU
     }
-
-    // https://gemspec.gematik.de/docs/gemSpec/gemSpec_IDP_Sek/gemSpec_IDP_Sek_V2.3.0/index.html#A_22989-01
-    public enum Scope {
-      AGE,
-      DISPLAY_NAME,
-      EMAIL,
-      GENDER,
-      DATE_OF_BIRTH,
-      FIRST_NAME,
-      LAST_NAME,
-      INSURED_PERSON
-    }
   }
 
   record RenderModel(
       String vfsConfirmation,
       String memberId,
       String organisationName,
-      String issuerUri,
+      String fachdienstName,
+      String fachdienstUri,
       String environment,
       String contactEmail,
-      int scopeAge,
-      int scopeDisplayName,
-      int scopeEmail,
-      int scopeGender,
-      int scopeDateOfBirth,
-      int scopeFirstName,
-      int scopeLastName,
-      int scopeInsuredPerson,
+      List<StringValue> scopes,
+      List<StringValue> redirectUris,
       List<PublicKey> publicKeys) {
 
-    public static RenderModel fromModel(Model m) {
-
+    static RenderModel fromModel(Model m) {
       return new RenderModel(
-          m.vfsConfirmation(),
+          emptyIfNull(m.vfsConfirmation()),
           m.memberId(),
-          m.organisationName(),
+          emptyIfNull(m.organisationName()),
+          emptyIfNull(m.fachdienstName()),
           m.issuerUri().toString(),
           m.environment().name(),
-          m.contactEmail(),
-          m.scopes().contains(Scope.AGE) ? 1 : 0,
-          m.scopes().contains(Scope.DISPLAY_NAME) ? 1 : 0,
-          m.scopes().contains(Scope.EMAIL) ? 1 : 0,
-          m.scopes().contains(Scope.GENDER) ? 1 : 0,
-          m.scopes().contains(Scope.DATE_OF_BIRTH) ? 1 : 0,
-          m.scopes().contains(Scope.FIRST_NAME) ? 1 : 0,
-          m.scopes().contains(Scope.LAST_NAME) ? 1 : 0,
-          m.scopes().contains(Scope.INSURED_PERSON) ? 1 : 0,
+          emptyIfNull(m.contactEmail()),
+          m.scopes().stream().map(StringValue::new).toList(),
+          m.redirectUris().stream().map(StringValue::new).toList(),
           m.jwks().getKeys().stream().map(RenderModel::toPublicKey).toList());
+    }
+
+    private static String emptyIfNull(String s) {
+      return s == null ? "" : s;
     }
 
     private static PublicKey toPublicKey(JWK key) {
@@ -173,7 +110,6 @@ public class RegistratonFormRenderer {
     }
 
     private static String encodeAsPem(Key k, String type) {
-
       var encoded = Base64.getEncoder().encodeToString(k.getEncoded());
 
       var sb = new StringBuilder();
@@ -189,6 +125,8 @@ public class RegistratonFormRenderer {
       sb.append("-----END %s-----%n".formatted(type));
       return sb.toString();
     }
+
+    record StringValue(String value) {}
 
     record PublicKey(String kid, String pem) {}
   }

--- a/ehealthid-cli/src/test/java/com/oviva/ehealthid/cli/RegistratonFormRendererTest.java
+++ b/ehealthid-cli/src/test/java/com/oviva/ehealthid/cli/RegistratonFormRendererTest.java
@@ -12,7 +12,6 @@ import com.nimbusds.jose.jwk.KeyUse;
 import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
 import com.oviva.ehealthid.cli.forms.RegistratonFormRenderer;
 import com.oviva.ehealthid.cli.forms.RegistratonFormRenderer.Model;
-import com.oviva.ehealthid.cli.forms.RegistratonFormRenderer.Model.Scope;
 import java.net.URI;
 import java.security.SecureRandom;
 import java.util.List;
@@ -29,41 +28,45 @@ class RegistratonFormRendererTest {
             new Model(
                 "VFS_DiGA_Test",
                 "FDmyDiGAMemb",
+                "My DiGA Org",
                 "My DiGA",
                 "bobby.tables@example.com",
                 URI.create("https://mydiga.example.com"),
                 PU,
-                List.of(Scope.INSURED_PERSON, Scope.EMAIL, Scope.DISPLAY_NAME),
+                List.of("openid", "urn:telematik:versicherter", "urn:telematik:email"),
+                List.of("https://mydiga.example.com/auth/callback"),
                 new JWKSet(key)));
 
     assertEquals(
         """
-                <?xml version="1.0" encoding="UTF-8"?>
-                <registrierungtifoederation>
-                  <datendesantragstellers>
-                  <vfsbestaetigung>VFS_DiGA_Test</vfsbestaetigung>
-                  <teilnehmertyp>Fachdienst</teilnehmertyp>
-                  <organisationsname>My DiGA</organisationsname>
-                  <memberid>FDmyDiGAMemb</memberid>
-                  <zwg>ORG-0229:BT-0170</zwg>
-                  <issueruri>https://mydiga.example.com</issueruri>
-                  <scopes>
-                    <scopealter>0</scopealter>
-                    <scopeanzeigename>1</scopeanzeigename>
-                    <scopeemail>1</scopeemail>
-                    <scopegeschlecht>0</scopegeschlecht>
-                    <scopegeburtsdatum>0</scopegeburtsdatum>
-                    <scopevorname>0</scopevorname>
-                    <scopenachname>0</scopenachname>
-                    <scopeversicherter>1</scopeversicherter>
-                  </scopes>
-                  <publickeys>
-                    <kidjwt>wXOS7cMWjpUGqySA-BwnbmiQSaaWBpEmy4xf08CHQXQ</kidjwt>
-                    <pubkeyjwt>-----BEGIN PUBLIC KEY-----&#10;MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE2lFRaRRzJx0Tspr8nT526HTY0LCQ&#10;g8WJhXI+LNXvmjbYokHMfZzM9xerR/u+Y/q1VK9NSH2cbXfGAmT24gC4DQ&#61;&#61;&#10;-----END PUBLIC KEY-----&#10;</pubkeyjwt>
-                  </publickeys>
-                  </datendesantragstellers>
-                </registrierungtifoederation>
-                """,
+        <?xml version="1.0" encoding="UTF-8"?>
+        <registrierungtifoederation>
+          <teilnehmertyp>Fachdienst</teilnehmertyp>
+          <betriebsumgebung>PU</betriebsumgebung>
+          <kontaktemail>bobby.tables@example.com</kontaktemail>
+          <vfsbestaetigung>VFS_DiGA_Test</vfsbestaetigung>
+          <zuweisungsgruppe>ORG-0229:BT-0170</zuweisungsgruppe>
+          <memberid>FDmyDiGAMemb</memberid>
+          <organisationsname>My DiGA Org</organisationsname>
+          <fachdienstname>My DiGA</fachdienstname>
+          <fachdiensturi>https://mydiga.example.com</fachdiensturi>
+          <scopes>
+            <scope>openid</scope>
+            <scope>urn:telematik:versicherter</scope>
+            <scope>urn:telematik:email</scope>
+          </scopes>
+          <claims/>
+          <redirect_uris>
+            <redirect_uri>https://mydiga.example.com/auth/callback</redirect_uri>
+          </redirect_uris>
+          <publickeysjwt>
+            <publickey>
+              <kid>wXOS7cMWjpUGqySA-BwnbmiQSaaWBpEmy4xf08CHQXQ</kid>
+              <key>-----BEGIN PUBLIC KEY-----&#10;MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE2lFRaRRzJx0Tspr8nT526HTY0LCQ&#10;g8WJhXI+LNXvmjbYokHMfZzM9xerR/u+Y/q1VK9NSH2cbXfGAmT24gC4DQ&#61;&#61;&#10;-----END PUBLIC KEY-----&#10;</key>
+            </publickey>
+          </publickeysjwt>
+        </registrierungtifoederation>
+        """,
         xml);
   }
 
@@ -73,42 +76,45 @@ class RegistratonFormRendererTest {
     var xml =
         RegistratonFormRenderer.render(
             new Model(
-                "VFS_DiGA_Test",
+                null,
                 "FDmyDiGAMemb",
+                "My DiGA Org",
                 "My DiGA",
                 "bobby.tables@example.com",
                 URI.create("https://mydiga.example.com"),
                 TU,
-                List.of(Scope.INSURED_PERSON, Scope.EMAIL, Scope.DISPLAY_NAME),
+                List.of("openid", "urn:telematik:versicherter", "urn:telematik:email"),
+                List.of("https://mydiga.example.com/auth/callback"),
                 new JWKSet(key)));
 
     assertEquals(
         """
         <?xml version="1.0" encoding="UTF-8"?>
         <registrierungtifoederation>
-           <datendesantragstellers>
-             <kontaktemail>bobby.tables@example.com</kontaktemail>
-             <teilnehmertyp>Fachdienst</teilnehmertyp>
-             <betriebsumgebung>TU</betriebsumgebung>
-             <organisationsname>My DiGA</organisationsname>
-             <memberid>FDmyDiGAMemb</memberid>
-             <zwg>ORG-0001:BT-0144</zwg>
-             <issueruri>https://mydiga.example.com</issueruri>
-             <scopes>
-               <scopealter>0</scopealter>
-               <scopeanzeigename>1</scopeanzeigename>
-               <scopeemail>1</scopeemail>
-               <scopegeschlecht>0</scopegeschlecht>
-               <scopegeburtsdatum>0</scopegeburtsdatum>
-               <scopevorname>0</scopevorname>
-               <scopenachname>0</scopenachname>
-               <scopeversicherter>1</scopeversicherter>
-             </scopes>
-             <publickeys>
-               <kidjwt>wXOS7cMWjpUGqySA-BwnbmiQSaaWBpEmy4xf08CHQXQ</kidjwt>
-               <pubkeyjwt>-----BEGIN PUBLIC KEY-----&#10;MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE2lFRaRRzJx0Tspr8nT526HTY0LCQ&#10;g8WJhXI+LNXvmjbYokHMfZzM9xerR/u+Y/q1VK9NSH2cbXfGAmT24gC4DQ&#61;&#61;&#10;-----END PUBLIC KEY-----&#10;</pubkeyjwt>
-             </publickeys>
-           </datendesantragstellers>
+          <teilnehmertyp>Fachdienst</teilnehmertyp>
+          <betriebsumgebung>TU</betriebsumgebung>
+          <kontaktemail>bobby.tables@example.com</kontaktemail>
+          <vfsbestaetigung></vfsbestaetigung>
+          <zuweisungsgruppe>ORG-0229:BT-0170</zuweisungsgruppe>
+          <memberid>FDmyDiGAMemb</memberid>
+          <organisationsname>My DiGA Org</organisationsname>
+          <fachdienstname>My DiGA</fachdienstname>
+          <fachdiensturi>https://mydiga.example.com</fachdiensturi>
+          <scopes>
+            <scope>openid</scope>
+            <scope>urn:telematik:versicherter</scope>
+            <scope>urn:telematik:email</scope>
+          </scopes>
+          <claims/>
+          <redirect_uris>
+            <redirect_uri>https://mydiga.example.com/auth/callback</redirect_uri>
+          </redirect_uris>
+          <publickeysjwt>
+            <publickey>
+              <kid>wXOS7cMWjpUGqySA-BwnbmiQSaaWBpEmy4xf08CHQXQ</kid>
+              <key>-----BEGIN PUBLIC KEY-----&#10;MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE2lFRaRRzJx0Tspr8nT526HTY0LCQ&#10;g8WJhXI+LNXvmjbYokHMfZzM9xerR/u+Y/q1VK9NSH2cbXfGAmT24gC4DQ&#61;&#61;&#10;-----END PUBLIC KEY-----&#10;</key>
+            </publickey>
+          </publickeysjwt>
         </registrierungtifoederation>
         """,
         xml);

--- a/ehealthid-rp/src/main/java/com/oviva/ehealthid/relyingparty/ConfigReader.java
+++ b/ehealthid-rp/src/main/java/com/oviva/ehealthid/relyingparty/ConfigReader.java
@@ -23,6 +23,7 @@ public class ConfigReader {
   public static final String CONFIG_FEDERATION_MASTER = "federation_master";
   public static final String CONFIG_ES_TTL = "es_ttl";
   public static final String CONFIG_APP_NAME = "app_name";
+  public static final String CONFIG_ORGANIZATION_NAME = "organization_name";
   public static final String CONFIG_APP_URI = "app_uri";
   public static final String CONFIG_SCOPES = "scopes";
 
@@ -72,6 +73,8 @@ public class ConfigReader {
 
     var appUri = configProvider.get(CONFIG_APP_URI).map(URI::create).orElse(null);
 
+    var organizationName = configProvider.get(CONFIG_ORGANIZATION_NAME).orElse(null);
+
     var entityStatementTtl =
         configProvider.get(CONFIG_ES_TTL).map(Duration::parse).orElse(Duration.ofHours(1));
 
@@ -80,6 +83,7 @@ public class ConfigReader {
             .sub(baseUri)
             .iss(baseUri)
             .appName(appName)
+            .organizationName(organizationName)
             .federationMaster(fedmaster)
             .ttl(entityStatementTtl)
             .scopes(getScopes())

--- a/ehealthid-rp/src/main/java/com/oviva/ehealthid/relyingparty/fed/FederationConfig.java
+++ b/ehealthid-rp/src/main/java/com/oviva/ehealthid/relyingparty/fed/FederationConfig.java
@@ -11,14 +11,16 @@ public record FederationConfig(
     Duration ttl,
     List<String> redirectUris,
     List<String> scopes,
-    String appName) {
+    String appName,
+    String organizationName) {
 
   public static Builder create() {
     return new Builder();
   }
 
   public Builder builder() {
-    return new Builder(iss, sub, federationMaster, ttl, redirectUris, scopes, appName);
+    return new Builder(
+        iss, sub, federationMaster, ttl, redirectUris, scopes, appName, organizationName);
   }
 
   public static final class Builder {
@@ -31,6 +33,7 @@ public record FederationConfig(
     private List<String> redirectUris;
     private List<String> scopes;
     private String appName;
+    private String organizationName;
 
     private Builder() {}
 
@@ -41,7 +44,8 @@ public record FederationConfig(
         Duration ttl,
         List<String> redirectUris,
         List<String> scopes,
-        String appName) {
+        String appName,
+        String organizationName) {
       this.iss = iss;
       this.sub = sub;
       this.federationMaster = federationMaster;
@@ -49,6 +53,7 @@ public record FederationConfig(
       this.redirectUris = redirectUris;
       this.scopes = scopes;
       this.appName = appName;
+      this.organizationName = organizationName;
     }
 
     public Builder iss(URI iss) {
@@ -86,8 +91,14 @@ public record FederationConfig(
       return this;
     }
 
+    public Builder organizationName(String organizationName) {
+      this.organizationName = organizationName;
+      return this;
+    }
+
     public FederationConfig build() {
-      return new FederationConfig(iss, sub, federationMaster, ttl, redirectUris, scopes, appName);
+      return new FederationConfig(
+          iss, sub, federationMaster, ttl, redirectUris, scopes, appName, organizationName);
     }
   }
 }

--- a/ehealthid-rp/src/main/java/com/oviva/ehealthid/relyingparty/fed/FederationEndpoint.java
+++ b/ehealthid-rp/src/main/java/com/oviva/ehealthid/relyingparty/fed/FederationEndpoint.java
@@ -49,6 +49,7 @@ public class FederationEndpoint {
                 Metadata.create()
                     .openIdRelyingParty(
                         OpenIdRelyingParty.create()
+                            .organizationName(federationConfig.organizationName())
                             .clientName(federationConfig.appName())
                             .jwks(relyingPartyJwks)
                             .responseTypes(List.of("code"))


### PR DESCRIPTION
**Added**

- Ability to configure the `metadata.openid_relying_party.organization_name`

**Changed**

- Moved the `cli` to the new format for registrations as per [Gematik Wiki](https://wiki.gematik.de/spaces/IDPKB/pages/544316583/Registrierung+eines+Fachdienstes+in+der+TI-F%C3%B6deration+f%C3%BCr+die+Referenzumgebung+RU+Testumgebung+TU)



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate integration risk because it changes the federation registration XML schema and the relying-party entity statement metadata fields used by external Gematik systems. Failures would surface at registration/metadata validation time rather than compile time.
> 
> **Overview**
> Updates the `fedreg` CLI to generate registration XML in Gematik’s new format, including explicit `fachdienstname`, a list-based `<scopes>` section, `<redirect_uris>`, and updated public key elements, while sourcing these values directly from the fetched entity configuration.
> 
> Extends the relying-party federation configuration to optionally read `organization_name` from config and emit it as `metadata.openid_relying_party.organization_name` in the `/.well-known/openid-federation` entity statement.
> 
> Also adds `.local` to `.gitignore`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c817dacf91bd5ae7e67c2e312c24f5506d493c2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->